### PR TITLE
[automation] Update go release version 1.17.10

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,7 +104,7 @@ linters-settings:
 
   gosimple:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "1.17.10"
 
   misspell:
     # Correct spellings using locale preferences for US or UK.
@@ -153,13 +153,13 @@ linters-settings:
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "1.17.10"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 
   stylecheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "1.17.10"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 
@@ -172,4 +172,4 @@ linters-settings:
 
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "1.17.10"


### PR DESCRIPTION
### What 
 Bump go release version with the latest release. 
 ### Further details 
 See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.17.10+label%3ACherryPickApproved) for 1.17.10