### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+---
+name: Bug
+about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/beats"
+
+---
+
+Please post all questions and issues on https://discuss.elastic.co/c/beats
+before opening a Github Issue. Your questions will reach a wider audience there,
+and if we confirm that there is a bug, then you can open a new issue.
+
+For security vulnerabilities please only send reports to security@elastic.co.
+See https://www.elastic.co/community/security for more information.
+
+Please include configurations and logs if available.
+
+For confirmed bugs, please report:
+- Version:
+- Operating System:
+- Discuss Forum URL:
+- Steps to Reproduce:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 ---
 name: Bug
-about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/beats"
+about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/elastic-stack/elastic-agent"
 
 ---
 
-Please post all questions and issues on https://discuss.elastic.co/c/beats
+Please post all questions and issues on https://discuss.elastic.co/c/elastic-stack/elastic-agent
 before opening a Github Issue. Your questions will reach a wider audience there,
 and if we confirm that there is a bug, then you can open a new issue.
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,10 +1,10 @@
 ---
 name: Bug
-about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/beats"
+about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/elastic-stack/elastic-agent"
 
 ---
 
-Please post all questions and issues on https://discuss.elastic.co/c/beats
+Please post all questions and issues on https://discuss.elastic.co/c/elastic-stack/elastic-agent
 before opening a Github Issue. Your questions will reach a wider audience there,
 and if we confirm that there is a bug, then you can open a new issue.
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,20 @@
+---
+name: Bug
+about: "Report confirmed bugs. For unconfirmed bugs please visit https://discuss.elastic.co/c/beats"
+
+---
+
+Please post all questions and issues on https://discuss.elastic.co/c/beats
+before opening a Github Issue. Your questions will reach a wider audience there,
+and if we confirm that there is a bug, then you can open a new issue.
+
+For security vulnerabilities please only send reports to security@elastic.co.
+See https://www.elastic.co/community/security for more information.
+
+Please include configurations and logs if available.
+
+For confirmed bugs, please report:
+- Version:
+- Operating System:
+- Discuss Forum URL
+- Steps to Reproduce:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,10 @@
+---
+name: Enhancement request
+about: Elastic-Agent Inputs can't do all the things, but maybe it can do your things.
+
+---
+
+**Describe the enhancement:**
+
+**Describe a specific use case for the enhancement or feature:**
+

--- a/.github/ISSUE_TEMPLATE/flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/flaky-test.md
@@ -1,0 +1,19 @@
+---
+name: Flaky Test
+about: Report a flaky test (one that doesn't pass consistently)
+labels: flaky-test
+---
+
+## Flaky Test
+
+* **Test Name:** Name of the failing test.
+* **Link:** Link to file/line number in github.
+* **Branch:** Git branch the test was seen in. If a PR, the branch the PR was based off.
+* **Artifact Link:** If available, attach the generated zip artifact associated with the stack trace for this failure.
+* **Notes:** Additional details about the test. e.g. theory as to failure cause
+
+### Stack Trace
+
+```
+paste stack trace here
+```

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -15,7 +15,7 @@ your questions there. In additional to awesome, knowledgeable community
 contributors, core Elastic-Agent-Inputs developers are on the forums every single day to help
 you out.
 
-The forums are here: https://discuss.elastic.co/c/beats
+The forums are here: https://discuss.elastic.co/c/elastic-stack/elastic-agent
 
 We can't stop you from opening an issue here, but it will likely
 linger without a response for days or weeks before it is closed and we

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,23 @@
+---
+name: Question
+about: Who, what, when, where, and how?
+
+---
+
+Hey, stop right there!
+
+We use GitHub to track feature requests and bug reports. Please do not
+submit issues for questions about how to use features of Beat, how to
+set Beats up, best practices, or development related help.
+
+However, we do want to help! Head on over to our official Elastic-Agent-Inputs forums and ask
+your questions there. In additional to awesome, knowledgeable community
+contributors, core Elastic-Agent-Inputs developers are on the forums every single day to help
+you out.
+
+The forums are here: https://discuss.elastic.co/c/beats
+
+We can't stop you from opening an issue here, but it will likely
+linger without a response for days or weeks before it is closed and we
+ask you to join us on the forums instead. Save yourself the time, and
+ask on the forums today.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Directories
+/.vagrant
+/.idea
+/.vscode
+/build
+/*/*.template*.json
+**/html_docs
+
+# Files
+.DS_Store
+*.dev.yml
+*.generated.yml
+coverage.out
+.python-version
+*.keystore
+go_env.properties
+mage_output_file.go
+
+# Editor swap files
+*.swp
+*.swo
+*.swn
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+*.exe
+*.test
+*.prof
+*.pyc
+
+# Terraform
+*.terraform
+*.tfstate*
+
+# Files generated with the bump version automations
+*.bck


### PR DESCRIPTION
## What does this PR do?

Add templates for issue creation. Because we still do not have a
discuss, all links still point to Beats discuss.

A `.gitignore` file is also added.

## Why is it important?

It helps to keep the issues organised.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
## Related issues
- Closes https://github.com/elastic/elastic-agent-inputs/issues/24

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~