### PR TITLE
Fix unit state used to signal shutdown

### DIFF
--- a/inputs/loadgenerator/core.go
+++ b/inputs/loadgenerator/core.go
@@ -122,7 +122,7 @@ func (l *loadGenerator) removeUnit(unit *client.Unit) {
 // handleUnitModified wraps any functions needed to manage changes to a unit
 func (l *loadGenerator) handleUnitModified(unit *client.Unit) {
 	state, _, _ := unit.Expected()
-	if state == client.UnitStateStopping {
+	if state == client.UnitStateStopped {
 		l.tearDownUnit(unit)
 	} else {
 		l.logger.Debugf("Got updated unit state: %s", state)

--- a/inputs/loadgenerator/core_test.go
+++ b/inputs/loadgenerator/core_test.go
@@ -115,7 +115,7 @@ func TestWithMockServer(t *testing.T) {
 					if time.Since(start) > runtime {
 						t.Logf("Sending stopped config...")
 						//remove the units once they've been healthy for a given period of time
-						return createUnitsWithState(proto.State_STOPPING, expectedLoadGen, unitOneID, 1)
+						return createUnitsWithState(proto.State_STOPPED, expectedLoadGen, unitOneID, 1)
 					}
 					//otherwise, just remove the units
 				} else if observed.Units[0].State == proto.State_STOPPED {


### PR DESCRIPTION
## What does this PR do?

Small issue I noticed. The elastic-agent will request a shutdown with `UnitStateStopped`, not `UnitStateStopping`.

In the future, we may want to separate out the unit types that are used for updating status, versus the ones that are used to signal status changes by elastic-agent itself.